### PR TITLE
Adding a Meson build and C bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ int2
 *debug*
 *~
 lib-static/*.a
+GPATH
+GRTAGS
+GTAGS

--- a/include/fmm2d/helmholtz.h
+++ b/include/fmm2d/helmholtz.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <complex.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void hfmm2d_s_c_p(double eps, double _Complex zk, int64_t ns, double const *sources, double _Complex const *charge, double _Complex *pot, int64_t *ier);
+
+#ifdef __cplusplus
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,95 @@
+project('fmm2d', ['fortran', 'c'])
+
+pkg = import('pkgconfig')
+
+fmm2d_src = [
+  # ./src/biharmonic
+  'src/biharmonic/bh2dterms.f',
+  'src/biharmonic/bhfmm2d.f',
+  'src/biharmonic/bhfmm2dwrap.f',
+  'src/biharmonic/bhkernels2d.f',
+  'src/biharmonic/bhndiv2d.f',
+  'src/biharmonic/bhrouts2d.f',
+
+  # ./src/common
+  'src/common/cdjseval2d.f',
+  'src/common/cumsum.f',
+  # 'src/common/dfft.f', # TODO: unused?
+  'src/common/dfft_threadsafe.f',
+  'src/common/dlaran.f',
+  'src/common/fmmcommon2d.f',
+  'src/common/hank103.f',
+  'src/common/hkrand.f',
+  'src/common/next235.f',
+  'src/common/prini.f',
+  'src/common/pts_tree2d.f',
+  'src/common/tree_routs2d.f',
+
+  # ./src/helmholtz
+  'src/helmholtz_c.f03', # c wrappers
+  'src/helmholtz/h2dcommon.f',
+  'src/helmholtz/h2dterms.f',
+  'src/helmholtz/helmkernels2d.f',
+  'src/helmholtz/helmrouts2d.f',
+  'src/helmholtz/hfmm2d.f',
+  'src/helmholtz/hfmm2d_mps.f',
+  'src/helmholtz/hfmm2d_mps_ndiv.f',
+  'src/helmholtz/hfmm2d_ndiv.f',
+  'src/helmholtz/hfmm2dwrap.f',
+  'src/helmholtz/hfmm2dwrap_vec.f',
+  'src/helmholtz/hndiv2d.f',
+  'src/helmholtz/wideband2d.f',
+
+  # ./src/laplace
+  'src/laplace/cauchykernels2d.f',
+  'src/laplace/cfmm2d.f',
+  'src/laplace/cfmm2d_ndiv.f',
+  'src/laplace/cfmm2dwrap.f',
+  'src/laplace/cfmm2dwrap_vec.f',
+  'src/laplace/l2dterms.f',
+  'src/laplace/lapkernels2d.f',
+  'src/laplace/laprouts2d.f',
+  'src/laplace/lfmm2d.f',
+  'src/laplace/lfmm2d_ndiv.f',
+  'src/laplace/lfmm2dwrap.f',
+  'src/laplace/lfmm2dwrap_vec.f',
+  'src/laplace/lndiv2d.f',
+  'src/laplace/rfmm2d.f',
+  'src/laplace/rfmm2d_ndiv.f',
+  'src/laplace/rfmm2dwrap.f',
+  'src/laplace/rfmm2dwrap_vec.f',
+  'src/laplace/rlapkernels2d.f',
+
+  # TODO: there's some code generation using happening with the
+  # modified biharmonic kernel (commented out lines below). Look into
+  # this later.
+
+  # ./src/modified-biharmonic
+  # 'src/modified-biharmonic/jinjaroot.yaml',
+  # 'src/modified-biharmonic/jinjaroot.yaml.py',
+  # 'src/modified-biharmonic/mbhfmm2d.f',
+  # 'src/modified-biharmonic/mbhgreen2d.f',
+  # 'src/modified-biharmonic/mbhkernels2d.f',
+  # 'src/modified-biharmonic/mbhkernels2d.f.j2',
+  # 'src/modified-biharmonic/mbhrouts2d.f',
+  # 'src/modified-biharmonic/mbhrouts2d.f.j2',
+
+  # ./src/stokes
+  'src/stokes/stfmm2d.f',
+  'src/stokes/stokkernels2d.f',
+]
+
+# TODO: set these the right way using meson instead of doing it manually...
+fmm2d_fortran_args = ['-fPIC', '-O3', '-march=native', '-funroll-loops', '-std=legacy', '-w']
+fmm2d_c_args = ['-std=c99'] + fmm2d_fortran_args
+
+fmm2d_lib = library(
+  'fmm2d',
+  fmm2d_src,
+  fortran_args : fmm2d_fortran_args,
+  install : true
+)
+
+install_subdir('include/fmm2d', install_dir : 'include', install_tag : 'devel')
+
+pkg.generate(fmm2d_lib)

--- a/src/helmholtz_c.f03
+++ b/src/helmholtz_c.f03
@@ -1,0 +1,16 @@
+module c_helmholtz
+  use iso_c_binding
+contains
+  subroutine c_hfmm2d_s_c_p(eps, zk, ns, sources, charge, pot, ier) &
+       bind(c, name='hfmm2d_s_c_p')
+    implicit none
+    real(c_double), value :: eps
+    complex(c_double_complex), value, intent(in) :: zk
+    integer(c_int64_t), value :: ns
+    real(c_double), intent(in) :: sources(2, ns)
+    complex(c_double_complex), intent(in) :: charge(ns)
+    complex(c_double_complex), intent(out) :: pot(ns)
+    integer(c_int64_t), intent(out) :: ier
+    call hfmm2d_s_c_p(eps, zk, ns, sources, charge, pot, ier)
+  end subroutine c_hfmm2d_s_c_p
+end module c_helmholtz


### PR DESCRIPTION
Thought I would create a PR here to check and see if there is any interest in this being fleshed out more. If not, feel free to close and I will just maintain in parallel in my own fork.

I'm going to be using the HF-FMM for some comparisons with my butterfly code for solving Helmholtz in 2D and was pointed to this library. My butterfly library is written in C and is built with [Meson](https://mesonbuild.com/), and I wanted to be able to pull this library in as a [Meson dependency](https://mesonbuild.com/Dependencies.html) easily without having to spend any time messing around in Fortran. So, this PR has the start of two additions to fmm2d:

**A meson build system.** This is currently in [meson.build](https://github.com/sampotter/fmm2d/blob/main/meson.build). This can be maintained concurrently with the existing set of Makefiles used to build fmm2d. IMO, using a system like Meson has significant benefits over handwritten Makefiles---the major one being that it would make it trivial to pull fmm2d into a Meson project (such as my butterfly library). FWIW, all of this applies equally well to CMake, but I've abandoned CMake for my own use in favor of Meson.

Using Meson, doing something like:

```
meson setup builddir
cd builddir
meson compile
meson install
```

will result in a shared library, the C headers (see below), and a pkg-config file being installed to the right place. The pkg-config file makes it possible to automatically figure out the various compiler flags needed to link against fmm2d, which is useful if someone wants to depend on fmm2d even if they are _not_ using Meson.

**C bindings.** I noticed there are a few headers in [c/include](https://github.com/sampotter/fmm2d/tree/main/c/include) wrapping some of the Helmholtz utility functions. I'm not sure if these are being used for anything, so I didn't want to mess with them. I started adding some C bindings using the newer iso_c_binding stuff, which has the advantage of all of the adapting from C to Fortran being done automatically (e.g., automatically convert pass-by-value in C to pass-by-reference in Fortran, automatically convert between 0-indexed C arrays and 1-indexed Fortran arrays, etc.).

So far I've done this for a single function from the 2D Helmholtz FMM wrappers, `hfmm2d_s_c_p`, and verified that the arguments are being passed in correctly. The relevant files are [include/fmm2d/helmholtz.h](https://github.com/sampotter/fmm2d/blob/main/include/fmm2d/helmholtz.h) and [src/helmholtz_c.f03](https://github.com/sampotter/fmm2d/blob/main/src/helmholtz_c.f03). The former is just a header file defining the C prototype, and the latter is a module using iso_c_binding which contains the Fortran wrapper function. This gives a simple template that can be worked from to wrap other functions in fmm2d---should be quite straightforward. Also, note that I haven't touched any of the existing Makefiles... they will only be built if Meson is being used.

Also, I noticed one odd thing, which might be a compiler bug, or might just be down to my lack of expertise with Fortran. On line 8 of helmholtz_c.f03, if `intent(in)` is omitted, only the real part of `zk` will be set (!). Setting `intent(in)` for other things passed by value (`eps` and `ns`) seems to be unnecessary. I was unable to find any documentation explaining why this might be the case.