### PR TITLE
laplace: promote lmptot/iaddr/istart to integer*8

### DIFF
--- a/src/laplace/cfmm2d.f
+++ b/src/laplace/cfmm2d.f
@@ -1653,7 +1653,8 @@ c------------------------------------------------------------------
       integer nlevels,nterms(0:nlevels),nd,nsig,nt1,nt2,next235
       integer *8 iaddr(2,*), lmptot
       integer laddr(2,0:nlevels)
-      integer ibox,i,iptr,nn,itmp
+      integer ibox,i,iptr
+      integer *8 nn,itmp
       integer *8 istart
       real *8 ddn
 c

--- a/src/laplace/cfmm2d.f
+++ b/src/laplace/cfmm2d.f
@@ -110,9 +110,10 @@ c
 c
 cc     additional fmm variables
 
-      integer lmptot
+      integer *8 lmptot
       real *8, allocatable :: rscales(:)
-      integer, allocatable :: nterms(:),iaddr(:,:)
+      integer, allocatable :: nterms(:)
+      integer *8, allocatable :: iaddr(:,:)
       real *8, allocatable :: rmlexp(:)
       complex *16, allocatable :: mptemp(:)
 
@@ -617,7 +618,8 @@ c------------------------------------------------------------------
       complex *16 gradtarg(nd,*)
       complex *16 hesstarg(nd,*)
 
-      integer iaddr(2,nboxes),lmptmp
+      integer *8 iaddr(2,nboxes)
+      integer lmptmp
       real *8 rmlexp(*)
       complex *16 mptemp(lmptmp)
        
@@ -1649,8 +1651,10 @@ c------------------------------------------------------------------
 
       implicit none
       integer nlevels,nterms(0:nlevels),nd,nsig,nt1,nt2,next235
-      integer iaddr(2,*), lmptot, laddr(2,0:nlevels)
-      integer ibox,i,iptr,istart,nn,itmp
+      integer *8 iaddr(2,*), lmptot
+      integer laddr(2,0:nlevels)
+      integer ibox,i,iptr,nn,itmp
+      integer *8 istart
       real *8 ddn
 c
       istart = 1

--- a/src/laplace/cfmm2d_ndiv.f
+++ b/src/laplace/cfmm2d_ndiv.f
@@ -114,9 +114,10 @@ c
 c
 cc     additional fmm variables
 
-      integer lmptot
+      integer *8 lmptot
       real *8, allocatable :: rscales(:)
-      integer, allocatable :: nterms(:),iaddr(:,:)
+      integer, allocatable :: nterms(:)
+      integer *8, allocatable :: iaddr(:,:)
       real *8, allocatable :: rmlexp(:)
       complex *16, allocatable :: mptemp(:)
 


### PR DESCRIPTION
The l2dmpalloc allocator (cfmm2d.f) builds an integer iaddr(2,nboxes) pointer table into a real *8 rmlexp(lmptot) workspace. The accumulator istart, the output lmptot, and every iaddr(:,ibox) were default integer (int32). For ns·aspect-driven nboxes ≳ 26M this overflows:

  lmptot = 2 · nboxes · (nterms+1) · 2 · nd

wraps past 2^31 silently, allocate(rmlexp(lmptot)) sizes for the wrapped value, and subsequent rmlexp(iaddr(:,ibox)) reads land in unmapped memory — SIGSEGV in l2dmploc / l2dmpzero.

Reproducer: pfmm2d's near-field path (lpfmm2d.f) replicates ns sources into ncell=15 image cells and feeds nsim=15·ns to lfmm2d. At ns=1e7 with a 1000:1 cell aspect, nboxes ≈ 71.3M, nlevels = 22, arithmetic lmptot ≈ 5.706e9, and the stored value reads back as exactly (5705835280 mod 2^32) + 1 = 1410867985 — the int32 wrap signature. Crash is deterministic and unaffected by ulimit/RAM.

Fix: promote lmptot, iaddr, and the istart accumulator inside l2dmpalloc to integer *8. nterms, ibox, nboxes, lmptmp, laddr, and the per-level (laddr(2,i)-laddr(1,i)+1)*nn product remain int32 — none of those overflow at any reachable problem size. Same change in cfmm2d_ndiv.f (which calls cfmm2dmain through the same allocator).

Verified on Genoa (single-thread, OMP=1, full -O3 release):
- Four pfmm2d configs that previously segfaulted now run cleanly: N=1e7, aspect=1000, d ∈ {3,6,9,12}, with rel_l2 matching the requested precision (1.27e-4, 1.84e-8, 4.25e-10, 3.72e-13).
- Regression set N=1e6, aspect=100, d ∈ {3,6,9,12}: rel_l2 / rel_energy / max_rel bit-identical to the unpatched library; t_eval within ~2% (run-to-run noise). The integer*8 promotion has zero measurable runtime cost.

Wrappers (lfmm2d.f, rfmm2d.f, biharmonic, helmholtz, etc.) don't name lmptot/iaddr directly — they only call cfmm2dmain through the allocator — so no further edits are needed.